### PR TITLE
Format dates for odoo payload

### DIFF
--- a/src/app/api/push-to-odoo/route.ts
+++ b/src/app/api/push-to-odoo/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { splitPdfByInvoices, generateTaskId } from '@/lib/pdf-splitter';
 import { OdooBillPayload, Invoice } from '@/types';
 import { storePdf } from '@/lib/pdf-storage';
+import { normalizeToOdooDateFormat } from '@/lib/utils';
 
 export const dynamic = 'force-dynamic'; // Prevent caching
 
@@ -198,8 +199,8 @@ export async function POST(request: NextRequest) {
           // Use original working format (camelCase, nested objects)
           invoiceNumber: rawInvoiceNumber,
           customerPoNumber: invoice.customerPoNumber || '',
-          invoiceDate: invoice.invoiceDate,
-          dueDate: invoice.dueDate,
+          invoiceDate: normalizeToOdooDateFormat(invoice.invoiceDate),
+          dueDate: normalizeToOdooDateFormat(invoice.dueDate),
           vendor: {
             name: invoice.vendor.name,
             address: invoice.vendor.address,


### PR DESCRIPTION
Normalize `invoiceDate` and `dueDate` to `yyyy/mm/dd` format in the Odoo payload to ensure consistent date formatting as required by ZUM-255.

---
Linear Issue: [ZUM-255](https://linear.app/zuma-group/issue/ZUM-255/maintain-consistent-date-format-in-payload)

<a href="https://cursor.com/background-agent?bcId=bc-2e95f55f-c7a8-4f3a-9396-cc12d83e8176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e95f55f-c7a8-4f3a-9396-cc12d83e8176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

