### PR TITLE
Update payload with tax information

### DIFF
--- a/src/app/api/push-to-odoo/route.ts
+++ b/src/app/api/push-to-odoo/route.ts
@@ -179,9 +179,19 @@ export async function POST(request: NextRequest) {
         const lines = [...baseLines];
 
         if (Math.abs(taxAmountValue) > 0) {
+          // Determine tax description based on tax type
+          let taxDescription = 'Sales Tax';
+          const taxType = invoice.taxType?.toUpperCase() || '';
+          
+          if (taxType.includes('GST')) {
+            taxDescription = 'GST 5%';
+          } else if (taxType.includes('PST')) {
+            taxDescription = 'PST 7%';
+          }
+
           lines.push({
             product_code: 'TAX',
-            description: 'Sales Tax',
+            description: taxDescription,
             quantity: 1,
             unit_price: taxAmountValue,
             discount: 0,

--- a/src/app/api/push-to-odoo/route.ts
+++ b/src/app/api/push-to-odoo/route.ts
@@ -230,8 +230,10 @@ export async function POST(request: NextRequest) {
             amount: item.amount,
             tax: item.tax
           })),
+          lines,  // Includes line items + tax line for Odoo processing
           subtotal: subtotalValue,
           taxAmount: taxAmountValue,
+          taxType: invoice.taxType,  // Show the tax type (GST, PST, etc.)
           total: totalAmountValue,
           currency: 'USD',  // Force to USD to ensure valid currency_id mapping in Odoo
           paymentTerms: invoice.paymentTerms || 'NET 30 DAYS',

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -135,6 +135,7 @@ export async function extractInvoiceData(base64: string, mimeType: string): Prom
         ],
         "subtotal": number,
         "taxAmount": number,
+        "taxType": "string" or null (Extract tax type - look for: GST, PST, GST 5%, PST 7%, etc. Return exact text as shown on invoice),
         "total": number,
         "currency": "string",
         "paymentTerms": "string" or null,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export interface Invoice {
   lineItems: LineItem[];
   subtotal: number;
   taxAmount: number;
+  taxType?: string; // Tax type: GST, PST, etc.
   total: number;
   currency: string;
   paymentTerms: string;


### PR DESCRIPTION
Add tax type extraction and conditional formatting to the payload to send specific tax descriptions (GST 5% or PST 7%) based on invoice content.

---
Linear Issue: [ZUM-261](https://linear.app/zuma-group/issue/ZUM-261/add-tax-in-the-payload)

<a href="https://cursor.com/background-agent?bcId=bc-aa68875e-26be-489c-b7a0-1d5ee6186dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa68875e-26be-489c-b7a0-1d5ee6186dcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

